### PR TITLE
Removing type: "module" so that it can be used with require() also

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "mongoose-softdelete",
   "description": "Mongoose plugin that enables soft deletion of Models/Documents.",
   "version": "1.2.0",
-  "type": "module",
   "homepage": "http://riyadhalnur.github.io/mongoose-softdelete",
   "keywords": [
     "mongoose",


### PR DESCRIPTION
Adding a type:"modue" treats the package as module which must be included using import statement and not require()